### PR TITLE
Adds "font-display: swap" CSS property for google fonts.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -115,7 +115,7 @@ add_action( 'wp_enqueue_scripts', 'envince_scripts', 1 );
  */
 function envince_block_editor_styles()
 {
-	wp_enqueue_style('envince-editor-googlefonts', '//fonts.googleapis.com/css?family=Raleway|Open+Sans');
+	wp_enqueue_style('envince-editor-googlefonts', '//fonts.googleapis.com/css?family=Raleway|Open+Sans&display=swap');
 	wp_enqueue_style('envince-block-editor-styles', get_template_directory_uri() . '/style-editor-block.css');
 }
 add_action('enqueue_block_editor_assets', 'envince_block_editor_styles', 1, 1);
@@ -132,7 +132,7 @@ function envince_scripts() {
 
 	$suffix = hybrid_get_min_suffix();
 
-	wp_register_style( 'envince-googlefonts', '//fonts.googleapis.com/css?family=Raleway|Open+Sans' );
+	wp_register_style( 'envince-googlefonts', '//fonts.googleapis.com/css?family=Raleway|Open+Sans&display=swap' );
 	wp_enqueue_style( 'envince-googlefonts' );
 
 	/* Load the bootstrap files */

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,12 @@ Envince WordPress Theme, Copyright (c) 2015, ThemeGrill
 Envince is distributed under the terms of the GNU GPL
 
 ## Changelog
+## Version TBD =
+* Enhancement - Added CSS font-display property and swap value for better performance.
+
+## Version 1.3.0 - 2021-05-07 =
+* Tweak - Update screenshot image source link.
+
 ## Version 1.2.9 - 2021-02-25 =
 * Tweak - Update screenshot image.
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ Envince is distributed under the terms of the GNU GPL
 
 == Changelog ==
 = Version TBD =
-* Enhancement - Added 'font-display: swap' CSS property for fonts to ensure better load performance.
+* Enhancement - Added CSS font-display property and swap value for better performance.
 
 = Version 1.3.0 - 2021-05-07 =
 * Tweak - Update screenshot image source link.

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ Envince WordPress Theme, Copyright (c) 2015, ThemeGrill
 Envince is distributed under the terms of the GNU GPL
 
 == Changelog ==
+= Version TBD =
+* Enhancement - Added 'font-display: swap' CSS property for fonts to ensure better load performance.
+
 = Version 1.3.0 - 2021-05-07 =
 * Tweak - Update screenshot image source link.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
>Adds 'font-display:swap' CSS property for fonts. This ensures that our fonts remains visible and also ensures better load performance.
### Type of change
- [ ] Code Refactor
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test the changes in this Pull Request:
1. Use google inbuilt tool "Light House".
2. Change fonts options from the customizer.
3. There must not be any error related to fonts that say "Ensure fonts remains visible during page reload".

### Checklist:
- [x] My code follows WordPress' coding standards
- [ ] I've checked to ensure there are no other open Pull Requests for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have made perform a test that proves my fix is effective or that my feature works
### Did you test this issue fix on all browsers?
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] opera
### Changelog entry
> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.